### PR TITLE
Fixing Pentaho reports call as earlier call was not passing authentication header.

### DIFF
--- a/app/scripts/controllers/savings/ViewSavingDetailsController.js
+++ b/app/scripts/controllers/savings/ViewSavingDetailsController.js
@@ -1,6 +1,6 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
-        ViewSavingDetailsController: function (scope, routeParams, resourceFactory, paginatorService, location, $uibModal, route, dateFilter, $sce, $rootScope, API_VERSION) {
+        ViewSavingDetailsController: function (scope, routeParams, resourceFactory, paginatorService, location, $uibModal, route, dateFilter, $sce, $rootScope, API_VERSION, http) {
             scope.report = false;
             scope.hidePentahoReport = true;
             scope.showActiveCharges = true;
@@ -426,7 +426,29 @@
                 }
 
                 // allow untrusted urls for iframe http://docs.angularjs.org/error/$sce/insecurl
-                scope.viewReportDetails = $sce.trustAsResourceUrl(scope.baseURL);
+                //scope.viewReportDetails = $sce.trustAsResourceUrl(scope.baseURL);
+
+                //fixing UI issue as above call giving 401 due to token header missing
+                // http://docs.angularjs.org/error/$sce/insecurl
+                scope.baseURL = $sce.trustAsResourceUrl(scope.baseURL);
+                scope.baseURL = $sce.valueOf(scope.baseURL);
+                http.get(scope.baseURL, {responseType: 'arraybuffer'})
+                    .then(function(response) {
+                        let data = response.data;
+                        let status = response.status;
+                        let headers = response.headers;
+                        let config = response.config;
+                        var contentType = headers('Content-Type');
+                        var file = new Blob([data], {type: contentType});
+                        var fileContent = URL.createObjectURL(file);
+
+                        // Pass the form data to the iframe as a data url.
+                        scope.viewReportDetails = $sce.trustAsResourceUrl(fileContent);
+                  })
+                .catch(function(error){
+                    $log.error(`Error loading ${scope.reportType} report`);
+                    $log.error(error);
+                });
 
             };
 
@@ -448,7 +470,29 @@
                     scope.baseURL += "&" + reportParams;
                 }
                 // allow untrusted urls for iframe http://docs.angularjs.org/error/$sce/insecurl
-                scope.viewReportDetails = $sce.trustAsResourceUrl(scope.baseURL);
+                //scope.viewReportDetails = $sce.trustAsResourceUrl(scope.baseURL);
+
+                ////fixing UI issue as above call giving 401 due to token header missing
+                // http://docs.angularjs.org/error/$sce/insecurl
+                scope.baseURL = $sce.trustAsResourceUrl(scope.baseURL);
+                scope.baseURL = $sce.valueOf(scope.baseURL);
+                http.get(scope.baseURL, {responseType: 'arraybuffer'})
+                    .then(function(response) {
+                        let data = response.data;
+                        let status = response.status;
+                        let headers = response.headers;
+                        let config = response.config;
+                        var contentType = headers('Content-Type');
+                        var file = new Blob([data], {type: contentType});
+                        var fileContent = URL.createObjectURL(file);
+
+                        // Pass the form data to the iframe as a data url.
+                        scope.viewReportDetails = $sce.trustAsResourceUrl(fileContent);
+                  })
+                .catch(function(error){
+                    $log.error(`Error loading ${scope.reportType} report`);
+                    $log.error(error);
+                });
 
             };
 
@@ -516,7 +560,7 @@
 
         }
     });
-    mifosX.ng.application.controller('ViewSavingDetailsController', ['$scope', '$routeParams', 'ResourceFactory','PaginatorService' , '$location','$uibModal', '$route', 'dateFilter', '$sce', '$rootScope', 'API_VERSION', mifosX.controllers.ViewSavingDetailsController]).run(function ($log) {
+    mifosX.ng.application.controller('ViewSavingDetailsController', ['$scope', '$routeParams', 'ResourceFactory','PaginatorService' , '$location','$uibModal', '$route', 'dateFilter', '$sce', '$rootScope', 'API_VERSION', '$http', mifosX.controllers.ViewSavingDetailsController]).run(function ($log) {
         $log.info("ViewSavingDetailsController initialized");
     });
 }(mifosX.controllers || {}));


### PR DESCRIPTION
Fixing Pentaho reports call as earlier call was not passing authentication header.

## Description
Fixing Pentaho reports call as earlier call was not passing authentication header.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
