### PR TITLE
grunt:devcode dependency replacement - "grunt-preprocess": "5.1.0"

### DIFF
--- a/.github/workflows/deploy-mifos-to-s3.workflow.yml
+++ b/.github/workflows/deploy-mifos-to-s3.workflow.yml
@@ -66,7 +66,7 @@ jobs:
           bower install
       - name: Install Node dependencies
         run: |
-          npm install
+          npm install --force
           npm install grunt-contrib-compass --save-dev
       - name: Install Gem dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install -g bower
 RUN npm install -g grunt-cli
 COPY . /usr/src/app
 RUN bower --allow-root install
-RUN npm install
+RUN npm install --force
 RUN bundle install
 RUN grunt prod
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -349,24 +349,18 @@ module.exports = function(grunt) {
       }
     },
 
-    devcode: {
-      options: {
-        html: true,        // html files parsing?
-        js: true,          // javascript files parsing?
-        css: false,         // css files parsing?
-        clean: true,       // removes devcode comments even if code was not removed
-        block: {
-          open: 'devcode', // with this string we open a block of code
-          close: 'endcode' // with this string we close a block of code
-        },
-        dest: 'dist'       // default destination which overwrittes environment variable
-      },
-      dist : {             // settings for task used with 'devcode:dist'
+    preprocess: {
+      dist: {
+        src: ['dist/**/*.js','dist/**/*.html','dist/*.js','dist/*.html'],
+        dst: ['dist/'],
         options: {
-            source: 'dist/',
-            dest: 'dist/',
-            env: 'production'
+            inline: true,
+            context: {
+              DEBUG: false,
+              NODE_ENV: 'production'
+            }
         }
+
       }
     },
 
@@ -425,7 +419,7 @@ module.exports = function(grunt) {
 
   // Default task(s).
   grunt.registerTask('default', ['clean', 'jshint', 'copy:dev']);
-  grunt.registerTask('prod', ['clean:dist', 'clean:server', 'compass:dist', 'copy:prod', 'copy:tests', 'concat', 'uglify:prod', 'devcode:dist', 'hashres','replace']);
+  grunt.registerTask('prod', ['clean:dist', 'clean:server', 'compass:dist', 'copy:prod', 'copy:tests', 'concat', 'uglify:prod', 'preprocess:dist', 'hashres','replace']);
   grunt.registerTask('dev', ['clean', 'compass:dev', 'copy:dev']);
   grunt.registerTask('test', ['karma']);
   grunt.registerTask('deploy', ['prod', 'gh-pages']);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-requirejs": "1.0.0",
     "grunt-contrib-uglify": "5.0.0",
     "grunt-contrib-watch": "1.1.0",
-    "grunt-devcode": "0.0.4",
+    "grunt-preprocess": "5.1.0",
     "grunt-gh-pages": "4.0.0",
     "grunt-hashres": "0.4.1",
     "grunt-html-validation": "0.1.18",


### PR DESCRIPTION
## Description
Mifos UI build is broken because grunt:devcode dependency is messed up. Replacing it with "grunt-preprocess": "5.1.0"

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
